### PR TITLE
Update Dockertag, Readme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-order
-      DOCKER_TAG: 1.0.1
       SERVICE_PORT: 8080
       GIT_FOLDER: OrderSrvc
 
@@ -121,7 +120,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-quote
-      DOCKER_TAG: 1.0.1
       SERVICE_PORT: 8080
       GIT_FOLDER: QuoteSrvc
 
@@ -170,7 +168,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-shipment
-      DOCKER_TAG: 1.0.1
       SERVICE_PORT: 8080
       GIT_FOLDER: ShipmentSrvc
 
@@ -219,7 +216,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-catalog
-      DOCKER_TAG: 1.0.1
       SERVICE_PORT: 8080
       GIT_FOLDER: CatalogSrvc
 
@@ -264,7 +260,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-dealer
-      DOCKER_TAG: 1.0.1
       GIT_FOLDER: DealerService
 
     steps:
@@ -320,7 +315,6 @@ jobs:
 
     environment:
       DOCKER_IMAGE: pumrp-web
-      DOCKER_TAG: 1.0.1
       GIT_FOLDER: Web
       SERVICE_PORT: 8080
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,15 @@ or here for the same [Parts Unlimited MRP application](http://aka.ms/pumrplabs) 
 
 To read and learn more about this project, please visit the [documentation website](https://microsoft.github.io/PartsUnlimitedMRPmicro/).
 
+CircleCI Build status: [![CircleCI](https://circleci.com/gh/Microsoft/PartsUnlimitedMRPmicro/tree/master.svg?style=svg)](https://circleci.com/gh/Microsoft/PartsUnlimitedMRPmicro/tree/master)
+
 ## Key Features
 
-- Entire application is dockerized and runs on Azure Container Service with Kubernetes orchestrator
+- Entire application is dockerized and runs on [Azure Container Service](https://docs.microsoft.com/azure/aks/) (AKS) or any other Kubernetes cluster
 - Front end service - runs Apache Tomcat and talks to all microservices services utilizing Hystrix and JSP.
 - Catalog, Order, Shipment, and Quote microservices - are Java spring APIs and call DocDb using the MongoDB driver.
 - Dealer microservice - is a .Net Core API using C#
+- Microservices and frontend container [images are available on Docker hub](https://hub.docker.com/r/microsoft/pumrp-web/).
 
 ## Contributing
 


### PR DESCRIPTION
- Remove the DOCKER_TAG environment variable so we can increment this value in CircleCI without having to update the .circle.yaml code.
- Update Readme to have CircleCI badge, update name for AKS, add link to Docker hub images